### PR TITLE
Only return message types

### DIFF
--- a/src/slack-reactions.coffee
+++ b/src/slack-reactions.coffee
@@ -91,7 +91,8 @@ module.exports = (robot) ->
           matches = result.messages.matches
           hits = []
 
-          matches = matches.filter (m) -> m.type != "group"
+          # Only show messages in public rooms
+          matches = matches.filter (m) -> m.type == "message"
 
           if matches.length == 0
             msg.send "No reactions found =("


### PR DESCRIPTION
This is a small bug but slack now has type `im` and type `group`. So I'm switching this check to only show messages.
