### PR TITLE
package.json: accept hubot 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "datejs": "0.0.2"
   },
   "peerDependencies": {
-    "hubot": "2.x"
+    "hubot": ">=2.0"
   },
   "devDependencies": {
     "chai": "^2.1.1",
@@ -26,7 +26,7 @@
     "grunt-contrib-watch": "~0.6.1",
     "grunt-mocha-test": "~0.12.7",
     "grunt-release": "~0.11.0",
-    "hubot": "2.x",
+    "hubot": ">=2.0",
     "matchdep": "~0.3.0",
     "mocha": "^2.1.0",
     "sinon": "^1.13.0",


### PR DESCRIPTION
The current version string doesn't accept `3.x` Hubot versions, so npm will complain about an unmet dependency when trying to install it alongside Hubot 3.